### PR TITLE
buildepoch.sh contains bashism

### DIFF
--- a/buildepoch.sh
+++ b/buildepoch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Script to built the Epoch Init System.
 
 CMD()


### PR DESCRIPTION
buildepoch.sh contains features not defined by POSIX, eg the '==' operator.
/bin/sh may be a symlink to a POSIX complaint shell other than bash.
